### PR TITLE
Rebuild development site for testing sticky footer and CNAME issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 _site
-sample.html
 CNAME

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 sample.html
+CNAME

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-binghamtonacm.com

--- a/_layouts/standard.html
+++ b/_layouts/standard.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>    
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
     <title>{{ page.title }} | {{ site.title }}</title>
 

--- a/_layouts/standard.html
+++ b/_layouts/standard.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>    
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
     <title>{{ page.title }} | {{ site.title }}</title>
 
@@ -13,9 +13,11 @@
 <body>
     {% include nav.html %}
 
-    <div class="container">
-        {{ content }}
-    </div>
+    <main>
+        <div class="container">
+            {{ content }}
+        </div>
+    </main>
 
     {% include footer.html %}
 

--- a/css/style.css
+++ b/css/style.css
@@ -69,6 +69,18 @@ a.svg:after {
     left: 0;
 }
 
+/* Sticky Footer */
+
+body {
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+}
+
+main {
+    flex: 1 0 auto;
+}
+
 /*----------------
     Front Page
 ------------------*/


### PR DESCRIPTION
GitHub triggered a "CNAME taken" alert because the CNAME was left in the branch. Removed the CNAME from the development build and added it to the .gitignore. As long as it remains in the master branch of the official repo, merging back will not be a problem. Also, the footer is now fixed to the bottom of the page.
