### PR TITLE
Remove broken link

### DIFF
--- a/eboard.html
+++ b/eboard.html
@@ -15,7 +15,7 @@ title: E-Board
         <div class="card">
             <div class="card-content">
                 <div class="card-title black-text border">Taylor Foxhall &bull; <strong>Chair</strong></div>
-                <p>Taylor is a third-year Computer Science and Math major. He maintains records of what is covered at board meetings. He also manages the chapter's <a href="{{ site.baseurl }}/projects-division.html">projects division</a> and programming competitions.</p>
+                <p>Taylor is a third-year Computer Science and Math major. He maintains records of what is covered at board meetings. He also manages the chapter's projects division and programming competitions.</p>
             </div>
             <div class="card-action">
                 <p class="contact-info"><i class="material-icons left">email</i> taylor <strong>(at)</strong> binghamtonacm.com</p>


### PR DESCRIPTION
The projects division no longer has the same URL. Remove the broken link. Projects Division URL previously renamed in 05cb8ec to reflect the projects page, since it makes sense to call the "Current Projects" page by what it is and not by projects-division.html
