### PR TITLE
Fix spacing in "what we do" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ title: Home
             <div class="card-content">
                 <h1 class="section-title center-align">What We Do</h1>
                 <hr />
-                <p>We hold programming competitions, problem solving workshops, and other fun events during the semester. We are also looking to send teams to the ICPC. <br>Find out more by reading our <a href="2015GIM.pdf">GIM slideshow</a>.</p>
+                <p>We hold programming competitions, problem solving workshops, and other fun events during the semester. We are also looking to send teams to the ICPC. Find out more by reading our <a href="2015GIM.pdf">GIM slideshow</a>.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Remove line break separating the descriptive text and the GIM slideshow PDF link.
